### PR TITLE
Use only bonds within atom group to build adjacency matrix

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -42,7 +42,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [macOS-latest, ubuntu-latest, windows-latest]
-          python-version: ["3.9", "3.10", "3.11", "3.11"]
+          python-version: ["3.9", "3.10", "3.11", "3.12"]
           mdanalysis-version: ["latest", "develop"]
 
     steps:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -42,7 +42,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [macOS-latest, ubuntu-latest, windows-latest]
-          python-version: ["3.9", "3.10", "3.11"]
+          python-version: ["3.9", "3.10", "3.11", "3.11"]
           mdanalysis-version: ["latest", "develop"]
 
     steps:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -42,7 +42,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [macOS-latest, ubuntu-latest, windows-latest]
-          python-version: ["3.9", "3.10", "3.11", "3.12"]
+          python-version: ["3.9", "3.10", "3.11"]
           mdanalysis-version: ["latest", "develop"]
 
     steps:

--- a/spyrmsdkit/analysis/utils.py
+++ b/spyrmsdkit/analysis/utils.py
@@ -24,19 +24,11 @@ def adjacency_matrix(ag):
     """
     n_atoms = len(ag)
 
-    # Allocate adjacency matrix
     A = np.zeros((n_atoms, n_atoms), dtype=int)
 
+    b = ag.get_connections("bonds", outside=False).to_indices()
+
     # Map bond indices to selection adjacency matrix
-    b = ag.bonds.to_indices()
-
-    # Remove dangling bonds
-    # An AtomGroup can contain bonds to atoms that are not part of the AtomGroup
-    mask = np.isin(b[:, 0], ag.atoms.indices) & np.isin(
-        b[:, 1], ag.atoms.indices
-    )
-    b = b[mask, :]
-
     # NumPy magic to re-index
     _, indices_flat = np.unique(b, return_inverse=True)
     indices = indices_flat.reshape(b.shape)

--- a/spyrmsdkit/analysis/utils.py
+++ b/spyrmsdkit/analysis/utils.py
@@ -5,7 +5,7 @@ Utility functions for analysis.
 import numpy as np
 
 
-def adjacency_matrix(atoms):
+def adjacency_matrix(ag):
     """
     Compute adjacency matrix for selection, based on bonds.
 
@@ -22,13 +22,22 @@ def adjacency_matrix(atoms):
     np.array
         Adjacency matrix
     """
-    n_atoms = len(atoms)
+    n_atoms = len(ag)
 
     # Allocate adjacency matrix
     A = np.zeros((n_atoms, n_atoms), dtype=int)
 
     # Map bond indices to selection adjacency matrix
-    b = atoms.bonds.to_indices()
+    b = ag.bonds.to_indices()
+
+    # Remove dangling bonds
+    # An AtomGroup can contain bonds to atoms that are not part of the AtomGroup
+    mask = np.isin(b[:, 0], ag.atoms.indices) & np.isin(
+        b[:, 1], ag.atoms.indices
+    )
+    b = b[mask, :]
+
+    # NumPy magic to re-index
     _, indices_flat = np.unique(b, return_inverse=True)
     indices = indices_flat.reshape(b.shape)
 

--- a/spyrmsdkit/analysis/utils.py
+++ b/spyrmsdkit/analysis/utils.py
@@ -22,9 +22,6 @@ def adjacency_matrix(ag):
     np.array
         Adjacency matrix
     """
-    n_atoms = len(ag)
-
-    A = np.zeros((n_atoms, n_atoms), dtype=int)
 
     b = ag.get_connections("bonds", outside=False).to_indices()
 
@@ -33,6 +30,7 @@ def adjacency_matrix(ag):
     _, indices_flat = np.unique(b, return_inverse=True)
     indices = indices_flat.reshape(b.shape)
 
+    n_atoms = len(ag)
     A = np.zeros((n_atoms, n_atoms), dtype=int)
     A[indices[:, 0], indices[:, 1]] = 1
 

--- a/spyrmsdkit/tests/analysis/test_spyrmsd.py
+++ b/spyrmsdkit/tests/analysis/test_spyrmsd.py
@@ -120,11 +120,6 @@ class TestSPyRMSD(object):
 
         B.load_new(np.array(coords), order="fac")
 
-        print(B.atoms)
-        print(B.bonds)
-        print(B.select_atoms("not type H").atoms)
-        print(B.select_atoms("not type H").bonds)
-
         return B.atoms
 
     @pytest.fixture()


### PR DESCRIPTION
When a selection cuts across bonds, the resulting `AtomGroup`'s `bond` attribute also contains bonds to atoms outside of the atom group. This results in an`IndexError` when building the adjacency matrix.

This PR uses `get_connections("bonds", outside=False)` to get only bonds within atoms of the selection, while the previous behavior corresponded to `get_connections("bonds", outside=True)`.

---


Thanks @ldx022 for testing out `spyrmsdkit` and reporting the issue in https://github.com/RMeli/spyrmsd/discussions/99.

Thanks @alibay for suggesting `get_connections()`, the original fix was the following:
```python
    b = ag.bonds.to_indices()

    # Remove dangling bonds
    # An AtomGroup can contain bonds to atoms that are not part of the AtomGroup
    mask = np.isin(b[:, 0], ag.atoms.indices) & np.isin(
        b[:, 1], ag.atoms.indices
    )
    b = b[mask, :]
```